### PR TITLE
bionic: Squash of pre-P mutex behavior restoration

### DIFF
--- a/libc/bionic/pthread_mutex.cpp
+++ b/libc/bionic/pthread_mutex.cpp
@@ -527,7 +527,8 @@ int pthread_mutex_init(pthread_mutex_t* mutex_interface, const pthread_mutexattr
         return EINVAL;
     }
 
-    if (((*attr & MUTEXATTR_PROTOCOL_MASK) >> MUTEXATTR_PROTOCOL_SHIFT) == PTHREAD_PRIO_INHERIT) {
+    if (((*attr & MUTEXATTR_PROTOCOL_MASK) >> MUTEXATTR_PROTOCOL_SHIFT) == PTHREAD_PRIO_INHERIT
+            && android_get_application_target_sdk_version() >= __ANDROID_API_P__) {
 #if !defined(__LP64__)
         if (state & MUTEX_SHARED_MASK) {
             return EINVAL;
@@ -782,17 +783,22 @@ static int MutexLockWithTimeout(pthread_mutex_internal_t* mutex, bool use_realti
 
 }  // namespace NonPI
 
-static inline __always_inline bool IsMutexDestroyed(uint16_t mutex_state) {
-    return mutex_state == 0xffff;
-}
-
 // Inlining this function in pthread_mutex_lock() adds the cost of stack frame instructions on
 // ARM64. So make it noinline.
-static int __attribute__((noinline)) HandleUsingDestroyedMutex(pthread_mutex_t* mutex,
-                                                               const char* function_name) {
+static bool __attribute__((noinline)) IsMutexDestroyed(uint16_t mutex_state) {
+    // Checking for mutex destruction is a P-specific behavior. Bypass the
+    // check if the SDK version precedes P, so that no change in behavior
+    // that may cause crashes is introduced.
     if (android_get_application_target_sdk_version() >= __ANDROID_API_P__) {
-        __fortify_fatal("%s called on a destroyed mutex (%p)", function_name, mutex);
+        return mutex_state == 0xffff;
+    } else {
+        return false;
     }
+}
+
+static int __always_inline HandleUsingDestroyedMutex(pthread_mutex_t* mutex,
+                                                     const char* function_name) {
+    __fortify_fatal("%s called on a destroyed mutex (%p)", function_name, mutex);
     return EBUSY;
 }
 


### PR DESCRIPTION
This is a squash of the following commits:

Author: Ethan Chen <intervigil@gmail.com>
Date:   Tue Sep 25 00:11:05 2018 -0700

    Actually restore pre-P mutex behavior

    Apps built against versions < P may not actually expect the EBUSY return
    code, and may crash or otherwise misbehave. Check for target SDK
    versions earlier than P when performing the IsMutexDestroyed check so
    any invocation of HandleUsingDestroyedMutex is bypassed and pre-P mutex
    behavior is restored.

    See 9e989f12d1186231d97dac6d038db7955acebdf3 for the change that
    introduced this new behavior.

    Change-Id: I45f8882c9527c63eed1ef5820a5004b8958d58ea

Author: nx111 <gd.zhangdz@gmail.com>
Date:   Wed Oct 3 16:58:19 2018 +0800

    bionic: Use legacy pthread_mutex_init() behavior on pre-P API levels

    * Google's changes to pthread_mutex_init is breaking RIL
      on certain Samsung devices like klte and hlte
    * To resolve this, add a check for their new additions
      to only apply the new behavior for P and higher APIs

    Change-Id: I41335c5c436fa28a66d044e6634466556dfd7f95

Author: Han Wang <416810799@qq.com>
Date:   Sat Sep 07 11:36:20 2019 +0200
Edit:   Forward-port to Q:
    s/bionic_get_application_target_sdk_version/android_get_application_target_sdk_version
    Drop incorrect inline keyword for IsMutexDestroyed()

Change-Id: Ia3eed5cfe2e5d40fa8b49aa5b4c565fb9632b8ec